### PR TITLE
Put adminimal into a subdir

### DIFF
--- a/make/compro.make
+++ b/make/compro.make
@@ -3,7 +3,7 @@ core = 7.x
 
 ; Core + Patches
 ; ---------------------
-projects[] = drupal
+projects[drupal][type] = core
 
 ; Contrib Modules
 ; ---------------------

--- a/make/compro.make
+++ b/make/compro.make
@@ -40,4 +40,4 @@ projects[compro][download][url] = https://github.com/tomgeekery/compro.git
 
 ; Themes
 ; ----------
-projects[] = adminimal
+;projects[] = adminimal

--- a/make/compro.make
+++ b/make/compro.make
@@ -23,7 +23,7 @@ projects[metatag][subdir] = contrib
 projects[block_class][subdir] = contrib
 projects[entity][subdir] = contrib
 projects[globalredirect][subdir] = contrib
-projects[adminimal_admin_menu] = contrib
+projects[adminimal_admin_menu][subdir] = contrib
 
 ; Custom Modules
 --------------------


### PR DESCRIPTION
drush make was failing because it was looking for 'contrib' as a version rather than the target directory.
